### PR TITLE
Avoid undefined Thumb-2 instructions using PC

### DIFF
--- a/arch/arm/boot/compressed/head.S
+++ b/arch/arm/boot/compressed/head.S
@@ -437,7 +437,9 @@ __setup_mmu:	sub	r3, r4, #16384		@ Page directory size
  */
 		mov	r1, #0x1e
 		orr	r1, r1, #3 << 10
-		mov	r2, pc, lsr #20
+ ARM(		mov	r2, pc, lsr #20		)
+ THUMB(		mov	r2,pc			)
+ THUMB(		lsr	r2,r2, #20		)
 		orr	r1, r1, r2, lsl #20
 		add	r0, r3, r2, lsl #2
 		str	r1, [r0], #4


### PR DESCRIPTION
The ADD and AND instructions using PC as one of the registers is not
supported by the Thumb-2 instruction set. This patch adds the THUMB()
variants in the compressed/head.S file.
