### PR TITLE
Update lpc178x_eth.c

### DIFF
--- a/drivers/net/arm/lpc178x_eth.c
+++ b/drivers/net/arm/lpc178x_eth.c
@@ -679,12 +679,11 @@ static int lpc_mdio_read(struct mii_bus *bus, int phy_id, int phyreg)
 	writel(LPC_MCMD_READ, LPC_ENET_MCMD(pldat->net_base));
 
 	/* Wait for unbusy status */
-	while (readl(LPC_ENET_MIND(pldat->net_base)) & LPC_MIND_BUSY) {
-		if (jiffies > timeout)
-			return -EIO;
-		cpu_relax();
+	for (i=0; i<0x5000; i++) {
+		if ((readl(LPC_ENET_MIND(pldat->net_base)) & LPC_MIND_BUSY)==0)
+			return -EIO; 
 	}
-
+	
 	lps = (int) readl(LPC_ENET_MRDD(pldat->net_base));
 	writel(0, LPC_ENET_MCMD(pldat->net_base));
 
@@ -701,10 +700,9 @@ static int lpc_mdio_write(struct mii_bus *bus, int phy_id, int phyreg,
 	writel(phydata, LPC_ENET_MWTD(pldat->net_base));
 
 	/* Wait for completion */
-	while (readl(LPC_ENET_MIND(pldat->net_base)) & LPC_MIND_BUSY) {
-		if (jiffies > timeout)
-			return -EIO;
-		cpu_relax();
+	for (i=0; i<0x5000; i++) {
+		if ((readl(LPC_ENET_MIND(pldat->net_base)) & LPC_MIND_BUSY)==0)
+			return -EIO; 
 	}
 
 	return 0;


### PR DESCRIPTION
Old code make errors and phy go to HALTED (usualy after downloading more than 30Mb or more)
Maybe problem in cpu_relax() - i'm dont know;
//Старый код выдавал иногда ошибку чтения/записи и phy переходил в режим HALTED